### PR TITLE
Update ctkp_rig.yaml

### DIFF
--- a/src/docs/rigs/ctkp_rig.yaml
+++ b/src/docs/rigs/ctkp_rig.yaml
@@ -4,7 +4,7 @@ supporting_data_sources:
   - infores_id: "infores:aact"
     name: "Aggregate Analysis of ClinicalTrial.gov (AACT)"
     description: "AACT is derived from researcher submissions to clinicaltrials.gov"
-    terms_of_use: "Not specified"
+    terms_of_use: "Freely available, with suggested acknowledge ment of the source. See https://aact.ctti-clinicaltrials.org/documentation/346"
     relevant_files:
       - file_name: "yyyymmdd_export_ctgov.zip"
         location: "https://aact.ctti-clinicaltrials.org/downloads"


### PR DESCRIPTION
I made some changes that I think make sense in light of the move from .md to .yaml format for authoring these RIGs.  

The approach here treats  infores:multiomics-ctkp as a DINGO ingest source, separate from the target output of the ingest (infores:translator-ctkp-kgx. This allows us to use the same RIG template as for regular external source ingests - but just including an additional `supporting_data_source_info` section.

I ported/integrated content from the existing .md RIG in the transator-ingest repo, and the existing .yaml rig in the rig repo - to create what I think is this final/complete CTKP RIG in a suitable format.

I will also update the rig schema and template to support this new `supporting-data-source-info` object

@gglusman it would be good to have your review/changes on content of this updated rig